### PR TITLE
Put message template on message property, remove messageTemplate property

### DIFF
--- a/src/JG.Core.Logging.Formatters/JsonFormatter.cs
+++ b/src/JG.Core.Logging.Formatters/JsonFormatter.cs
@@ -48,9 +48,6 @@ public class JsonFormatter : ITextFormatter
         output.Write(MapLogLevelNumber(logEvent.Level));
 
         output.Write(",\"message\":");
-        JsonValueFormatter.WriteQuotedJsonString(logEvent.RenderMessage(), output);
-
-        output.Write(",\"messageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
         if (logEvent.Properties.TryGetValue("app", out var app))


### PR DESCRIPTION
We already rely on `message` being the message template. It also makes sense to use that as a default as it's more concise, and columns for the interpolated parameters can be easily added in Logz.io. 

We could also add the rendered message on a separate property, but that seems wasteful, it's better to just configure Logz.io to display additional columns for the interpolated properties.