### PR TITLE
Remove use of logEvent.TraceId for correlation ID

### DIFF
--- a/src/JG.Core.Logging.Formatters/JsonFormatter.cs
+++ b/src/JG.Core.Logging.Formatters/JsonFormatter.cs
@@ -125,11 +125,6 @@ public class JsonFormatter : ITextFormatter
             return requestId.ToString();
         }
 
-        if (logEvent.TraceId.HasValue)
-        {
-            return logEvent.TraceId.Value.ToHexString();
-        }
-
         return null;
     }
 


### PR DESCRIPTION
This was backported from the old formatter but I don't think it's actually used properly anywhere and it's causing issues on .NET Framework.
