### PR TITLE
[ADO-3407922] Apply default CODEOWNERS file (team-tnt)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default team code ownership
+* @JustGiving/tnt


### PR DESCRIPTION
Added CODEOWNERS file for repository JG.Core with team @JustGiving/tnt

---
> 🤖 This PR was created by [service-mechanic/codeowners-enforce](https://github.com/JustGiving/service-mechanic/blob/master/src/fixes/codeowners-enforce.ts)